### PR TITLE
Fix V3127

### DIFF
--- a/Memstate.Postgresql/PostgresqlSettings.cs
+++ b/Memstate.Postgresql/PostgresqlSettings.cs
@@ -38,7 +38,7 @@
 
             if (string.IsNullOrWhiteSpace(SubscriptionStream))
             {
-                throw new ArgumentException("Property must have a value.", nameof(Table));
+                throw new ArgumentException("Property must have a value.", nameof(SubscriptionStream));
             }
         }
     }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. 

### V3127

- Two similar code fragments were found. Perhaps, this is a typo and 'SubscriptionStream' variable should be used instead of 'Table' Memstate.Postgresql PostgresqlSettings.cs 41