### PR TITLE
Fix V3005

### DIFF
--- a/Memstate.Test/Proxy/OperationAttributeMapToTests.cs
+++ b/Memstate.Test/Proxy/OperationAttributeMapToTests.cs
@@ -34,7 +34,7 @@ namespace Memstate.Tests.DispatchProxy
 
             public void SetCustomer(Customer c)
             {
-                Customer = Customer;
+                Customer = c;
             }
         }
 


### PR DESCRIPTION
Hello again from  Pinguem.ru competition on finding errors !  I found this  with PVS-Studio:

* The 'Customer' variable is assigned to itself. Memstate.Test OperationAttributeMapToTests.cs 37