### PR TITLE
Documentation placeholder chapter headings

### DIFF
--- a/Memstate.Docs.GettingStarted/BuiltInModels/BuiltInModelsTests.cs
+++ b/Memstate.Docs.GettingStarted/BuiltInModels/BuiltInModelsTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Memstate.Docs.GettingStarted.BuiltInModels
+{
+    public class BuiltInModelsTests
+    {
+    }
+}

--- a/Memstate.Docs.GettingStarted/BuiltInModels/readme.md
+++ b/Memstate.Docs.GettingStarted/BuiltInModels/readme.md
@@ -1,0 +1,5 @@
+# Built In Models
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
+built in models documentation coming (tbd)

--- a/Memstate.Docs.GettingStarted/BuiltInModels/readme.md
+++ b/Memstate.Docs.GettingStarted/BuiltInModels/readme.md
@@ -1,5 +1,5 @@
 # Built In Models
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 built in models documentation coming (tbd)

--- a/Memstate.Docs.GettingStarted/ClientAPI/ClientAPITests.cs
+++ b/Memstate.Docs.GettingStarted/ClientAPI/ClientAPITests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Memstate.Docs.GettingStarted.ClientAPI
+{
+    public class ClientAPITests
+    {
+    }
+}

--- a/Memstate.Docs.GettingStarted/ClientAPI/readme.md
+++ b/Memstate.Docs.GettingStarted/ClientAPI/readme.md
@@ -1,0 +1,5 @@
+# Client API
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
+client api documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/ClientAPI/readme.md
+++ b/Memstate.Docs.GettingStarted/ClientAPI/readme.md
@@ -1,5 +1,5 @@
 # Client API
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 client api documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/Configuration/ConfigurationTests.cs
+++ b/Memstate.Docs.GettingStarted/Configuration/ConfigurationTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Memstate.Docs.GettingStarted.Configuration
+{
+    class ConfigurationTests
+    {
+    }
+}

--- a/Memstate.Docs.GettingStarted/Configuration/readme.md
+++ b/Memstate.Docs.GettingStarted/Configuration/readme.md
@@ -1,0 +1,5 @@
+# Configuration
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
+configuration documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/Configuration/readme.md
+++ b/Memstate.Docs.GettingStarted/Configuration/readme.md
@@ -1,5 +1,5 @@
 # Configuration
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 configuration documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/Memstate.Docs.GettingStarted.csproj
+++ b/Memstate.Docs.GettingStarted/Memstate.Docs.GettingStarted.csproj
@@ -18,4 +18,10 @@
     <ProjectReference Include="..\Memstate\Memstate.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="System">
+      <HintPath>System</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/Memstate.Docs.GettingStarted/Modelling/ModelingTests.cs
+++ b/Memstate.Docs.GettingStarted/Modelling/ModelingTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Memstate.Docs.GettingStarted.Modelling
+{
+    class ModelingTests
+    {
+    }
+}

--- a/Memstate.Docs.GettingStarted/Modelling/readme.md
+++ b/Memstate.Docs.GettingStarted/Modelling/readme.md
@@ -1,0 +1,5 @@
+# Modelling
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
+modelling documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/Modelling/readme.md
+++ b/Memstate.Docs.GettingStarted/Modelling/readme.md
@@ -1,5 +1,5 @@
 # Modelling
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 modelling documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/EarnPoints.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/EarnPoints.cs
@@ -1,4 +1,4 @@
-﻿namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Commands
+﻿namespace Memstate.Docs.GettingStarted.QuickStart.Commands
 {
 
     public class EarnPoints : Command<LoyaltyDB, Customer>

--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/InitCustomer.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/InitCustomer.cs
@@ -1,4 +1,4 @@
-﻿namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Commands
+﻿namespace Memstate.Docs.GettingStarted.QuickStart.Commands
 {
 
     public class InitCustomer : Command<LoyaltyDB, Customer>

--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/SpendPoints.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/SpendPoints.cs
@@ -1,4 +1,4 @@
-﻿namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Commands
+﻿namespace Memstate.Docs.GettingStarted.QuickStart.Commands
 {
 
     public class SpendPoints : Command<LoyaltyDB, Customer>

--- a/Memstate.Docs.GettingStarted/QuickStart/Customer.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Customer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses
+namespace Memstate.Docs.GettingStarted.QuickStart
 {
     [Serializable]
     public class Customer

--- a/Memstate.Docs.GettingStarted/QuickStart/LoyaltyDB.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/LoyaltyDB.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses
+namespace Memstate.Docs.GettingStarted.QuickStart
 {
     [Serializable]
     public class LoyaltyDB

--- a/Memstate.Docs.GettingStarted/QuickStart/Queries/GetCustomers.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Queries/GetCustomers.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Queries
+namespace Memstate.Docs.GettingStarted.QuickStart.Queries
 {
     public class GetCustomers : Query<LoyaltyDB, IDictionary<int, Customer>>
     {

--- a/Memstate.Docs.GettingStarted/QuickStart/Queries/Top10Customers.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Queries/Top10Customers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Queries
+namespace Memstate.Docs.GettingStarted.QuickStart.Queries
 {
     [Serializable]
     public class Top10Customers : Query<LoyaltyDB, Customer[]>

--- a/Memstate.Docs.GettingStarted/QuickStart/QuickStartTests.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/QuickStartTests.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses;
-using Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Commands;
-using Memstate.Docs.GettingStarted._10_QuickStart.QuickStartClasses.Queries;
+using Memstate.Docs.GettingStarted.QuickStart.Commands;
+using Memstate.Docs.GettingStarted.QuickStart.Queries;
 using NUnit.Framework;
 
-namespace Memstate.Docs.GettingStarted._10_QuickStart
+namespace Memstate.Docs.GettingStarted.QuickStart
 {
     public class QuickStartTests
     {

--- a/Memstate.Docs.GettingStarted/QuickStart/readme.md
+++ b/Memstate.Docs.GettingStarted/QuickStart/readme.md
@@ -1,4 +1,7 @@
-# Quickstart Guide
+QuickStart Guide (getting started) | [Modelling](LoyaltyDB.cs)
+
+
+# Quickstart Guide (getting started)
 
 Here's a complete guide to get you started with developing your first Memstate application!
 The following topics are covered:
@@ -17,7 +20,7 @@ The Memstate.Core library is a single assembly. Grab the latest Memstate.Core.dl
 
 Create a class that derives from `Model` and add members to hold data, usually collections. Mark the class and any referenced types with the `Serializable` attribute. An instance of this class is your in-memory database.
 
-* example : [LoyaltyDB.cs](QuickStartClasses/LoyaltyDB.cs)
+* example : [LoyaltyDB.cs](LoyaltyDB.cs)
 
 ```csharp
     [Serializable]
@@ -32,8 +35,8 @@ Create a class that derives from `Model` and add members to hold data, usually c
 
 Commands are used to update the model. Derive from `Command<M>` or `Command<M,R>` where `M` is the type of your model and `R` is the result type
 
-* example : [SpendPoints.cs](QuickStartClasses/Commands/SpendPoints.cs)
-* example : [EarnPoints.cs](QuickStartClasses/Commands/EarnPoints.cs)
+* example : [SpendPoints.cs](Commands/SpendPoints.cs)
+* example : [EarnPoints.cs](Commands/EarnPoints.cs)
 
 ```csharp
     public class EarnPoints : Command<LoyaltyDB, Customer>
@@ -111,8 +114,12 @@ public class Top10Customers : Query<LoyaltyDB, Customer[]>
 Customer[] customers = engine.Execute(new Top10Customers());
 ```
 
+## Transactions
+
+(TBD) tests and documentation currently in progress.
+
 ## Summary
 
 We've covered the absolute basics here, but essentially there's not much more to developing than defining the model, and writing commands and queries. We used explicit transactions, an anemic model and the transaction script pattern. Next, you might wan't to check out [implicit transactions](../../modeling/proxy), where commands and queries are derived from methods on the model eliminating the need to explicitly author commands and queries.
 
-* For a full end to end working example see [QuickStart.cs](QuickStart.cs)
+* For a full end to end working example see [QuickStartTests.cs](QuickStartTests.cs)

--- a/Memstate.Docs.GettingStarted/QuickStart/readme.md
+++ b/Memstate.Docs.GettingStarted/QuickStart/readme.md
@@ -1,7 +1,6 @@
-QuickStart Guide (getting started) | [Modelling](../Modelling)
-
-
 # Quickstart Guide (getting started)
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 Here's a complete guide to get you started with developing your first Memstate application!
 The following topics are covered:

--- a/Memstate.Docs.GettingStarted/QuickStart/readme.md
+++ b/Memstate.Docs.GettingStarted/QuickStart/readme.md
@@ -1,6 +1,6 @@
 # Quickstart Guide (getting started)
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 Here's a complete guide to get you started with developing your first Memstate application!
 The following topics are covered:

--- a/Memstate.Docs.GettingStarted/QuickStart/readme.md
+++ b/Memstate.Docs.GettingStarted/QuickStart/readme.md
@@ -1,4 +1,4 @@
-QuickStart Guide (getting started) | [Modelling](LoyaltyDB.cs)
+QuickStart Guide (getting started) | [Modelling](../Modelling)
 
 
 # Quickstart Guide (getting started)

--- a/Memstate.Docs.GettingStarted/Security/SecurityTests.cs
+++ b/Memstate.Docs.GettingStarted/Security/SecurityTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Memstate.Docs.GettingStarted.Security
+{
+    class SecurityTests
+    {
+    }
+}

--- a/Memstate.Docs.GettingStarted/Security/readme.md
+++ b/Memstate.Docs.GettingStarted/Security/readme.md
@@ -1,5 +1,5 @@
 # Security
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 security documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/Security/readme.md
+++ b/Memstate.Docs.GettingStarted/Security/readme.md
@@ -1,0 +1,5 @@
+# Security
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
+security documentation coming. (tbd)

--- a/Memstate.Docs.GettingStarted/Storage/StorageTests.cs
+++ b/Memstate.Docs.GettingStarted/Storage/StorageTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Memstate.Docs.GettingStarted.Storage
+{
+    class StorageTests
+    {
+    }
+}

--- a/Memstate.Docs.GettingStarted/Storage/readme.md
+++ b/Memstate.Docs.GettingStarted/Storage/readme.md
@@ -1,5 +1,5 @@
 # Storage
 
-[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) | [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
 
 storage documentation coming (tbd)

--- a/Memstate.Docs.GettingStarted/Storage/readme.md
+++ b/Memstate.Docs.GettingStarted/Storage/readme.md
@@ -1,0 +1,5 @@
+# Storage
+
+[QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
+storage documentation coming (tbd)

--- a/Memstate.Docs.GettingStarted/readme.md
+++ b/Memstate.Docs.GettingStarted/readme.md
@@ -1,0 +1,10 @@
+# Memstate docs
+
+* [Memstate](../README.md)
+* [QuickStart Guide](/QuickStart)
+* [Modelling](/Modelling)
+* [Built in Models](/BuiltInModels)
+* [Configuration](/Configuration)
+* [Storage](/Storage)
+* [Client API](/ClientAPI)
+* [Security](/Security)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memstate
 
-[Memstate](readme.md) | [QuickStart Guide](Memstate.Docs.GettingStarted\QuickStart)  | [Modelling](Memstate.Docs.GettingStarted\Modelling) | [Built in Models](Memstate.Docs.GettingStarted\BuiltInModels) | [Configuration](Memstate.Docs.GettingStarted\Configuration) [Storage](StorageMemstate.Docs.GettingStarted\) | [Client API](ClientAPIMemstate.Docs.GettingStarted\) | [Security](Memstate.Docs.GettingStarted\Security)
+[Memstate](.\README.md) | [QuickStart Guide](Memstate.Docs.GettingStarted\QuickStart)  | [Modelling](Memstate.Docs.GettingStarted\Modelling) | [Built in Models](Memstate.Docs.GettingStarted\BuiltInModels) | [Configuration](Memstate.Docs.GettingStarted\Configuration) [Storage](StorageMemstate.Docs.GettingStarted\Storage) | [Client API](ClientAPIMemstate.Docs.GettingStarted\ClientAPI) | [Security](Memstate.Docs.GettingStarted\Security)
 
 [![Join the chat at https://gitter.im/DevrexLabs/memstate](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/DevrexLabs/memstate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 In-memory event-sourced ACID-transactional distributed object graph engine. Memstate is written in C# for .NET Standard 1.6. Memstate runs either embedded in your process or as a separate server process.
@@ -13,6 +13,7 @@ Your data fits in RAM. Moving it back and forth between disk and memory is a poi
 Memstate has many possible use cases but is designed primarily to handle complex OLTP workloads by replacing the datastore, data access and business logic layer in a typical enterprise application. It's also a great fit for stateful microservices.
 
 The benefits of using Memstate are huge:
+
 * Productivity/Cost - *Way* less code to write and maintain, typically less than 50%
 * Quality - strongly typed and compiled C# means less bugs and problems
 * Performance - In-memory is orders of magnitude faster than reading/writing to disk

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memstate
 
-[Memstate](.\README.md) | [QuickStart Guide](Memstate.Docs.GettingStarted\QuickStart)  | [Modelling](Memstate.Docs.GettingStarted\Modelling) | [Built in Models](Memstate.Docs.GettingStarted\BuiltInModels) | [Configuration](Memstate.Docs.GettingStarted\Configuration) [Storage](StorageMemstate.Docs.GettingStarted\Storage) | [Client API](ClientAPIMemstate.Docs.GettingStarted\ClientAPI) | [Security](Memstate.Docs.GettingStarted\Security)
+[Memstate](./README.md) | [QuickStart Guide](/Memstate.Docs.GettingStarted/QuickStart)  | [Modelling](/Memstate.Docs.GettingStarted/Modelling) | [Built in Models](/Memstate.Docs.GettingStarted/BuiltInModels) | [Configuration](/Memstate.Docs.GettingStarted/Configuration) [Storage](/StorageMemstate.Docs.GettingStarted/Storage) | [Client API](/ClientAPIMemstate.Docs.GettingStarted/ClientAPI) | [Security](/Memstate.Docs.GettingStarted/Security)
 
 [![Join the chat at https://gitter.im/DevrexLabs/memstate](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/DevrexLabs/memstate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 In-memory event-sourced ACID-transactional distributed object graph engine. Memstate is written in C# for .NET Standard 1.6. Memstate runs either embedded in your process or as a separate server process.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memstate
 
-[Memstate](readme.md) | [QuickStart Guide](QuickStart)  | [Modelling](Modelling) | [Built in Models](BuiltInModels) | [Configuration](Configuration) [Storage](Storage) | [Client API](ClientAPI) | [Security](Security)
+[Memstate](readme.md) | [QuickStart Guide](Memstate.Docs.GettingStarted\QuickStart)  | [Modelling](Memstate.Docs.GettingStarted\Modelling) | [Built in Models](Memstate.Docs.GettingStarted\BuiltInModels) | [Configuration](Memstate.Docs.GettingStarted\Configuration) [Storage](StorageMemstate.Docs.GettingStarted\) | [Client API](ClientAPIMemstate.Docs.GettingStarted\) | [Security](Memstate.Docs.GettingStarted\Security)
 
 [![Join the chat at https://gitter.im/DevrexLabs/memstate](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/DevrexLabs/memstate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 In-memory event-sourced ACID-transactional distributed object graph engine. Memstate is written in C# for .NET Standard 1.6. Memstate runs either embedded in your process or as a separate server process.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The benefits of using Memstate are huge:
 
 ## Quickstart - getting started
 
-[Full quick start getting started sample code here...](/Memstate.Docs.GettingStarted/_10_QuickStart)
+[Full quick start getting started sample code here...](/Memstate.Docs.GettingStarted/QuickStart)
 
 ## Governance, Support and Contributions
 Memstate is an open source project sponsored and governed by Devrex Labs, an LLC based in Sweden.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memstate
 
-[Memstate](./README.md) | [QuickStart Guide](/Memstate.Docs.GettingStarted/QuickStart)  | [Modelling](/Memstate.Docs.GettingStarted/Modelling) | [Built in Models](/Memstate.Docs.GettingStarted/BuiltInModels) | [Configuration](/Memstate.Docs.GettingStarted/Configuration) [Storage](/StorageMemstate.Docs.GettingStarted/Storage) | [Client API](/ClientAPIMemstate.Docs.GettingStarted/ClientAPI) | [Security](/Memstate.Docs.GettingStarted/Security)
+[Memstate](./README.md) | [QuickStart Guide](/Memstate.Docs.GettingStarted/QuickStart)  | [Modelling](/Memstate.Docs.GettingStarted/Modelling) | [Built in Models](/Memstate.Docs.GettingStarted/BuiltInModels) | [Configuration](/Memstate.Docs.GettingStarted/Configuration) | [Storage](/Memstate.Docs.GettingStarted/Storage) | [Client API](/Memstate.Docs.GettingStarted/ClientAPI) | [Security](/Memstate.Docs.GettingStarted/Security)
 
 [![Join the chat at https://gitter.im/DevrexLabs/memstate](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/DevrexLabs/memstate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 In-memory event-sourced ACID-transactional distributed object graph engine. Memstate is written in C# for .NET Standard 1.6. Memstate runs either embedded in your process or as a separate server process.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Memstate
 
+[Memstate](readme.md) | [QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+
 [![Join the chat at https://gitter.im/DevrexLabs/memstate](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/DevrexLabs/memstate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 In-memory event-sourced ACID-transactional distributed object graph engine. Memstate is written in C# for .NET Standard 1.6. Memstate runs either embedded in your process or as a separate server process.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memstate
 
-[Memstate](readme.md) | [QuickStart Guide](../QuickStart)  | [Modelling](../Modelling) | [Built in Models](../BuiltInModels) | [Configuration](../Configuration) [Storage](../Storage) | [Client API](../ClientAPI) | [Security](../Security)
+[Memstate](readme.md) | [QuickStart Guide](QuickStart)  | [Modelling](Modelling) | [Built in Models](BuiltInModels) | [Configuration](Configuration) [Storage](Storage) | [Client API](ClientAPI) | [Security](Security)
 
 [![Join the chat at https://gitter.im/DevrexLabs/memstate](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/DevrexLabs/memstate?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 In-memory event-sourced ACID-transactional distributed object graph engine. Memstate is written in C# for .NET Standard 1.6. Memstate runs either embedded in your process or as a separate server process.


### PR DESCRIPTION
I'm busy bringing in all the documentation so that users that stumble across memstate on github can get started quickly.

added common navigation to the root project and to the documentation. Renamed the docs folder to remove the ugly _10_ numbering prefix, renamed the namespaces and created placeholder projects, folders, and readme for the different documentation chapters.

Will start moving the documentation in after this is approved, and only after I've confirmed with tests that the documentation reflects what we're currently able to support. (or will alter the documentation to show what the required behaviour will be when  it's implemented. ) So that users can know what currently works, and what is not yet implemented from the documentation.