### PR TITLE
Move from XUnit to Nunit for Memstate.Test namespace

### DIFF
--- a/src/Memstate.Test/EngineTests.cs
+++ b/src/Memstate.Test/EngineTests.cs
@@ -1,19 +1,20 @@
 using System;
 using FakeItEasy;
-using Xunit;
 using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace Memstate.Test
 {
     public class EngineTests
     {
-        private readonly IJournalSubscriptionSource _fakeSubscriptionSource;
-        private readonly IJournalSubscription _fakeSubscription;
-        private readonly IJournalWriter _fakeJournalWriter;
-        private readonly Engine<Object> _engine;
-        private readonly int _nextRecordNumber;
-        
-        public EngineTests()
+        private IJournalSubscriptionSource _fakeSubscriptionSource;
+        private IJournalSubscription _fakeSubscription;
+        private IJournalWriter _fakeJournalWriter;
+        private Engine<Object> _engine;
+        private int _nextRecordNumber;
+
+        [SetUp]
+        public void Setup()
         {
             _fakeSubscriptionSource = A.Fake<IJournalSubscriptionSource>();
             _fakeSubscription = A.Fake<IJournalSubscription>();
@@ -28,15 +29,14 @@ namespace Memstate.Test
             _engine = new Engine<Object>(config, new Object(), _fakeSubscriptionSource, _fakeJournalWriter, _nextRecordNumber);
         }
 
-
-        [Fact]
+        [Test]
         public void Constructor_subscribes_to_journal_records_from_correct_recordNumber()
         {
             A.CallTo(() => _fakeSubscriptionSource.Subscribe(_nextRecordNumber, A<Action<JournalRecord>>._))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 
-        [Fact]
+        [Test]
         public async Task Subscription_is_disposed_when_engine_is_disposed()
         {
             await _engine.DisposeAsync().ConfigureAwait(false);
@@ -45,7 +45,7 @@ namespace Memstate.Test
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 
-        [Fact]
+        [Test]
         public async Task Writer_is_disposed_when_engine_is_disposed()
         { 
             await _engine.DisposeAsync().ConfigureAwait(false);

--- a/src/Memstate.Test/Memstate.Test.csproj
+++ b/src/Memstate.Test/Memstate.Test.csproj
@@ -13,8 +13,6 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit.Runners" Version="3.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Memstate.JsonNet\Memstate.JsonNet.csproj" />

--- a/src/Memstate.Test/Models/KeyValueStoreProxyTests.cs
+++ b/src/Memstate.Test/Models/KeyValueStoreProxyTests.cs
@@ -1,16 +1,18 @@
+using System.Collections.Generic;
 using Memstate.Models.KeyValue;
+using NUnit.Framework;
 
 namespace Memstate.Test.Models
 {
     using System;
     using Memstate.Models;
-    using Xunit;
 
     public class KeyValueStoreProxyTests
     {
-        private readonly IKeyValueStore<int> _keyValueStore;
+        private IKeyValueStore<int> _keyValueStore;
 
-        public KeyValueStoreProxyTests()
+        [SetUp]
+        public void Setup()
         {
             MemstateSettings config = new MemstateSettings();
             config.FileSystem = new InMemoryFileSystem();
@@ -20,35 +22,38 @@ namespace Memstate.Test.Models
             _keyValueStore = client.GetDispatchProxy();
         }
 
-        [Fact]
+        [Test]
         public void Set_stores_value()
         {
             _keyValueStore.Set("KEY", 1);
             var node = _keyValueStore.Get("KEY");
-            Assert.Equal(1, node.Value);
+            Assert.AreEqual(1, node.Value);
         }
 
-        [Fact]
+        [Test]
         public void Set_new_key_yields_correct_version()
         {
             _keyValueStore.Set("KEY", 1);
             var node = _keyValueStore.Get("KEY");
-            Assert.Equal(1, node.Version);
+            Assert.AreEqual(1, node.Version);
         }
 
-        [Fact]
+        [Test]
         public void Update_bumps_version()
         {
             _keyValueStore.Set("KEY", 1);
             _keyValueStore.Set("KEY", 2);
             var node = _keyValueStore.Get("KEY");
-            Assert.Equal(2, node.Version);
+            Assert.AreEqual(2, node.Version);
         }
 
-        [Fact]
+        [Test]
         public void Remove_throws_when_key_not_exists()
         {
-            Assert.ThrowsAny<Exception>(() => _keyValueStore.Remove("KEY"));
+            Assert.Throws<AggregateException> (() =>
+            {
+                _keyValueStore.Remove("KEY");
+            });
         }
     }
 }

--- a/src/Memstate.Test/Models/KeyValueStoreTests.cs
+++ b/src/Memstate.Test/Models/KeyValueStoreTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Memstate.Models;
-using Xunit;
+using NUnit.Framework;
 
 namespace Memstate.Test.Models
 {
@@ -9,33 +9,33 @@ namespace Memstate.Test.Models
     {
         private readonly KeyValueStore<string> _store = new KeyValueStore<string>();
 
-        [Fact]
+        [Test]
         public void Given_no_existing_data_When_getting_a_value_Should_throw_KeyNotFoundException()
         {
             Assert.Throws<KeyNotFoundException>(() => _store.Get("NON_EXISTING_KEY"));
         }
 
-        [Fact]
+        [Test]
         public void Given_key_exists_When_getting_a_value_Should_return_value()
         {
             _store.Set("EXISTING_KEY", "VALUE");
 
             var node = _store.Get("EXISTING_KEY");
 
-            Assert.Equal("VALUE", node.Value);
+            Assert.AreEqual("VALUE", node.Value);
         }
 
-        [Fact]
+        [Test]
         public void Given_no_existing_data_When_setting_a_value_Should_store_value()
         {
             _store.Set("EXISTING_KEY", "VALUE");
 
             var node = _store.Get("EXISTING_KEY");
 
-            Assert.Equal("VALUE", node.Value);
+            Assert.AreEqual("VALUE", node.Value);
         }
 
-        [Fact]
+        [Test]
         public void Given_key_was_removed_by_another_user_When_setting_a_value_Should_throw_mismatching_version_exception()
         {
             var version = _store.Set("EXISTING_KEY", "VALUE");
@@ -45,7 +45,7 @@ namespace Memstate.Test.Models
             Assert.Throws<InvalidOperationException>(() => _store.Set("EXISTING_KEY", "VALUE", version));
         }
 
-        [Fact]
+        [Test]
         public void Given_key_was_changed_by_another_user_When_setting_a_value_Should_throw_mismatching_version_exception()
         {
             var version = _store.Set("EXISTING_KEY", "VALUE");
@@ -55,7 +55,7 @@ namespace Memstate.Test.Models
             Assert.Throws<InvalidOperationException>(() => _store.Set("EXISTING_KEY", "VALUE", version));
         }
 
-        [Fact]
+        [Test]
         public void Given_key_exists_When_setting_a_value_Should_update_version_and_value()
         {
             var version = _store.Set("EXISTING_KEY", "VALUE");
@@ -65,16 +65,16 @@ namespace Memstate.Test.Models
             var node = _store.Get("EXISTING_KEY");
 
             Assert.True(newVersion > version);
-            Assert.Equal("NEW_VALUE", node.Value);
+            Assert.AreEqual("NEW_VALUE", node.Value);
         }
 
-        [Fact]
+        [Test]
         public void Given_no_existing_data_When_removing_a_value_Should_throw_KeyNotFoundException()
         {
             Assert.Throws<KeyNotFoundException>(() => _store.Get("EXISTING_KEY"));
         }
 
-        [Fact]
+        [Test]
         public void Given_key_was_changed_by_another_user_When_removing_a_value_Should_throw_exception_on_mismatching_version()
         {
             var version = _store.Set("EXISTING_KEY", "VALUE");
@@ -84,7 +84,7 @@ namespace Memstate.Test.Models
             Assert.Throws<InvalidOperationException>(() => _store.Remove("EXISTING_KEY", version));
         }
 
-        [Fact]
+        [Test]
         public void Given_key_exists_When_removing_a_value_Should_remove_node()
         {
             _store.Set("EXISTING_KEY", "VALUE");

--- a/src/Memstate.Test/PacketTests.cs
+++ b/src/Memstate.Test/PacketTests.cs
@@ -1,96 +1,93 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Memstate.Tcp;
-using Xunit;
+using NUnit.Framework;
 
 namespace Memstate.Test
 {
     public class PacketTests
     {
-        [Fact]
+        private static IList<int> _payloadSizes = new List<int>
+        {
+            0,
+            127,
+            4523
+        };
+
+        [Test]
         public void IsTerminal_is_default_when_calling_constructor()
         {
             var packet = new Packet();
-            Assert.True(packet.IsTerminal);
+            Assert.IsTrue(packet.IsTerminal);
         }
 
-        [Fact]
+        [Test]
         public void IsTerminal_is_default_when_creating_from_factory_method()
         {
-            var packet = Packet.Create(new byte[42], 42);
-            Assert.True(packet.IsTerminal);
+            Packet packet = Packet.Create(new byte[42], 42);
+            Assert.IsTrue(packet.IsTerminal);
         }
 
-        public static IEnumerable<object[]> PayloadSizes()
-        {
-            yield return new object[] { 0 };
-            yield return new object[] { 127 };
-            yield return new object[] { 4523 };
-        }
-
-        [MemberData(nameof(PayloadSizes))]
-        [Theory]
+        [TestCaseSource(nameof(_payloadSizes))]
         public async Task When_writing_to_stream_Size_property_corresponds_to_bytes_written(int payloadSize)
         {
-            var packet = Packet.Create(new byte[payloadSize], 1);
+            Packet packet = Packet.Create(new byte[payloadSize], 1);
 
             var memoryStream = new MemoryStream();
             await packet.WriteToAsync(memoryStream);
-            Assert.Equal(memoryStream.Length, packet.Size);
+            Assert.AreEqual(memoryStream.Length, packet.Size);
         }
 
-        [MemberData(nameof(PayloadSizes))]
-        [Theory]
-        public async void ReadAsync_returns_identical_packet(int payloadSize)
+        [TestCaseSource(nameof(_payloadSizes))]
+        public async Task ReadAsync_returns_identical_packet(int payloadSize)
         {
             //Arrange
-            var packet = Packet.Create(new byte[payloadSize], 1);
+            Packet packet = Packet.Create(new byte[payloadSize], 1);
             var stream = new MemoryStream();
             await packet.WriteToAsync(stream);
             stream.Position = 0;
             var token = new CancellationToken();
 
             //Act
-            var copy = await Packet.ReadAsync(stream, token);
+            Packet copy = await Packet.ReadAsync(stream, token);
 
             //Assert
-            Assert.Equal(packet.Size, copy.Size);
-            Assert.Equal(packet.MessageId, copy.MessageId);
-            Assert.Equal(packet.Info, copy.Info);
-            Assert.Equal(packet.Payload.Length, copy.Payload.Length);
+            Assert.AreEqual(packet.Size, copy.Size);
+            Assert.AreEqual(packet.MessageId, copy.MessageId);
+            Assert.AreEqual(packet.Info, copy.Info);
+            Assert.AreEqual(packet.Payload.Length, copy.Payload.Length);
         }
 
-        [MemberData(nameof(PayloadSizes))]
-        [Theory(Skip="doesn't terminate")]
-        public async void When_stream_is_blocked_cancelling_throws_a_TaskCancelledException(int payloadSize)
+        [Ignore("Doesn't terminate")]
+        [TestCaseSource(nameof(_payloadSizes))]
+        public async Task When_stream_is_blocked_cancelling_throws_a_TaskCancelledException(int payloadSize)
         {
             //Arrange
-            var packet = Packet.Create(new byte[payloadSize], 1);
-            var stream = new MemoryStream();
-            await packet.WriteToAsync(stream);
-            stream.SetLength(stream.Length - 3);
-            var cancellationSource = new CancellationTokenSource();
-            stream.Position = 0;
-
-            //Act
-            var task = Packet.ReadAsync(stream, cancellationSource.Token);
-            await Task.Delay(TimeSpan.FromMilliseconds(5));
-
-            //Assert
-            Assert.False(task.IsCompleted);
-            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            Packet packet = Packet.Create(new byte[payloadSize], 1);
+            using (var stream = new MemoryStream())
             {
-                cancellationSource.Cancel();
-                await task;
-            });
+                await packet.WriteToAsync(stream);
+                stream.SetLength(stream.Length - 3);
+                var cancellationSource = new CancellationTokenSource();
+                stream.Position = 0;
 
-            Assert.True(task.IsCompleted);
-            Assert.True(task.IsFaulted);
-            
+                //Act
+                var task = Packet.ReadAsync(stream, cancellationSource.Token);
+                // await Task.Delay(TimeSpan.FromMilliseconds(5));
+
+                //Assert
+                Assert.IsFalse(task.IsCompleted);
+                Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                {
+                    cancellationSource.Cancel();
+                    await task;
+                });
+
+                Assert.IsTrue(task.IsCompleted);
+                Assert.IsTrue(task.IsFaulted);
+            }
         }
-
     }
 }

--- a/src/Memstate.Test/Proxy/MethodMapTests.cs
+++ b/src/Memstate.Test/Proxy/MethodMapTests.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+﻿using NUnit.Framework;
 
 namespace Memstate.Test.Proxy
 {
@@ -56,70 +56,70 @@ namespace Memstate.Test.Proxy
         }
 
 
-        [Fact]
+        [Test]
         public void Maps_are_cached()
         {
             var map = MethodMap.MapFor<TestModel>();
-            Assert.Same(_map, map);
+            Assert.AreEqual(_map, map);
         }
 
-        [Fact]
+        [Test]
         public void Implicit_command_IsCommand()
         {
             var target = _map. GetOperationInfo("ImplicitCommand");
             Assert.True(target is CommandInfo<TestModel>);
         }
 
-        [Fact]
+        [Test]
         public void Explicit_command_IsCommand()
         {
             var target = _map.GetOperationInfo("ExplicitCommandWithResult");
             Assert.True(target is CommandInfo<TestModel>);
         }
 
-        [Fact]
+        [Test]
         public void Implicit_query_IsQuery()
         {
             var target = _map.GetOperationInfo("ImplicitQuery");
             Assert.True(target is QueryInfo<TestModel>);
         }
 
-        [Fact]
+        [Test]
         public void NoProxy_is_disallowed()
         {
             var target = _map.GetOperationInfo("NoProxyQuery");
             Assert.False(target.IsAllowed);
         }
 
-        [Fact]
+        [Test]
         public void Default_ResultIsIsolated_is_false_implicit()
         {
             var target = _map.GetOperationInfo("ImplicitQuery");
             Assert.False(target.OperationAttribute.Isolation.HasFlag(IsolationLevel.Output));
         }
 
-        [Fact]
+        [Test]
         public void Default_ResultIsIsolated_is_false_for_explicit()
         {
             var target = _map.GetOperationInfo("ExplicitCommandWithResult");
             Assert.False(target.OperationAttribute.Isolation.HasFlag(IsolationLevel.Output));
         }
 
-        [Fact]
+        [Test]
         public void Explicit_ResultIsIsolated_is_reported()
         {
             var target = _map.GetOperationInfo("MvccOperation");
             Assert.False(target.OperationAttribute.Isolation.HasFlag(IsolationLevel.Output));
         }
 
-        [Fact]
+        [Test]
         public void Implicit_internal_command_is_mapped()
         {
             //will throw unless exists
             _map.GetOperationInfo("InternalMethod");
         }
 
-        [Fact]
+        [Test]
         public void Implicit_internal_query_is_mapped()
         {
             _map.GetOperationInfo("InternalQuery");

--- a/src/Memstate.Test/Proxy/ProxyOverloadingTests.cs
+++ b/src/Memstate.Test/Proxy/ProxyOverloadingTests.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Linq;
-using Xunit;
+using NUnit.Framework;
 
 namespace Memstate.Test.DispatchProxy
 {
     public class ProxyOverloadingTests
     {
-        private readonly IModelWithOverloads _db;
+        private IModelWithOverloads _db;
 
-        public ProxyOverloadingTests()
+        [SetUp]
+        public void Setup()
         {
             var settings = new MemstateSettings().WithInmemoryStorage();
             var storageProvider = settings.CreateStorageProvider();
@@ -19,61 +20,61 @@ namespace Memstate.Test.DispatchProxy
             _db = client.GetDispatchProxy();
         }
 
-        [Fact]
+        [Test]
         public void CanCallNoArgMethod()
         {
             _db.Meth();
-           Assert.Equal(1, _db.GetCalls());
+           Assert.AreEqual(1, _db.GetCalls());
         }
 
-        [Fact]
+        [Test]
         public void CanCallOverloadWithAnArgument()
         {
             var inc = _db.Meth(42);
-            Assert.Equal(43, inc);
+            Assert.AreEqual(43, inc);
         }
 
-        [Fact]
+        [Test]
         public void CanCallWithParams()
         {
             
             var numbers = new[] {1, 2, 3, 4, 5};
             var sum = numbers.Sum();
             var result = _db.Meth(1,2,3,4,5);
-            Assert.Equal(sum, result);
+            Assert.AreEqual(sum, result);
         }
 
-        [Fact]
+        [Test]
         public void CanCallUsingNamedArgs()
         {
             var result = _db.Inc(with: 100, number: 200);
-            Assert.Equal(300, result);
+            Assert.AreEqual(300, result);
         }
 
-        [Fact]
+        [Test]
         public void CanCallWithArrayAsParams()
         {
             var numbers = new[] { 1, 2, 3, 4, 5 };
             var sum = numbers.Sum();
             var result = _db.Meth(numbers);
-            Assert.Equal(sum,result);
+            Assert.AreEqual(sum,result);
         }
 
-        [Fact]
+        [Test]
         public void CanHandleOptionalArgs()
         {
             var result = _db.Inc(20);
-            Assert.Equal(21, result);
+            Assert.AreEqual(21, result);
 
             result = _db.Inc(20, 5);
-            Assert.Equal(25,result);
+            Assert.AreEqual(25,result);
         }
 
 
         /// <summary>
         /// It should not be possible to use ref or out args
         /// </summary>
-        [Fact]
+        [Test]
         public void RefArgsNotAllowed()
         {
             Assert.Throws<Exception>(() =>
@@ -83,7 +84,7 @@ namespace Memstate.Test.DispatchProxy
             });
         }
 
-        [Fact]
+        [Test]
         public void OutArgsNotAllowed()
         {
             Assert.Throws<Exception>(() =>

--- a/src/Memstate.Test/TcpListenerTests.cs
+++ b/src/Memstate.Test/TcpListenerTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace Memstate.Test
 {
@@ -12,7 +12,7 @@ namespace Memstate.Test
         /// Verifies the assumption that the blocking TcpListener
         /// Accept*Async calls will return when the listener is stopped.
         /// </summary>
-        [Fact]
+        [Test]
         public void Accept_throws_when_Socket_is_closed()
         {
             TcpListener listener = new TcpListener(IPAddress.Any, 43675);
@@ -20,7 +20,10 @@ namespace Memstate.Test
             Task<TcpClient> task = listener.AcceptTcpClientAsync();
             Task.Delay(1000);
             listener.Stop();
-            Assert.Throws<AggregateException>(() => task.Result);
+            Assert.Throws<AggregateException>(() =>
+            {
+                TcpClient unused = task.Result;
+            });
         }
     }
 }


### PR DESCRIPTION
Summary
* Nunit conversion for Memstate.Test
* Remove the xunit project reference from Memstate.Test

Tests in this namespace are all green. No refactoring to differentiate between the suitability of Setup and OneTimeSetup. The changes should not have any effect on how test setup was working.