### PR TITLE
Simple_end_to_end_getting_started_configure_to_use_json_serializer_with_filesytem_storage

### DIFF
--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/EarnPoints.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/EarnPoints.cs
@@ -1,6 +1,5 @@
 ﻿namespace Memstate.Docs.GettingStarted.QuickStart.Commands
 {
-
     public class EarnPoints : Command<LoyaltyDB, Customer>
     {
         public EarnPoints()

--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/InitCustomer.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/InitCustomer.cs
@@ -1,6 +1,7 @@
-﻿namespace Memstate.Docs.GettingStarted.QuickStart.Commands
-{
+﻿using Newtonsoft.Json;
 
+namespace Memstate.Docs.GettingStarted.QuickStart.Commands
+{
     public class InitCustomer : Command<LoyaltyDB, Customer>
     {
         public InitCustomer()
@@ -13,7 +14,10 @@
             Points = points;
         }
 
+        [JsonProperty("ID")]
         public int ID { get; private set; }
+
+        [JsonProperty("Points")]
         public int Points { get; private set; }
 
         public override Customer Execute(LoyaltyDB model)

--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/SpendPoints.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/SpendPoints.cs
@@ -1,6 +1,5 @@
 ﻿namespace Memstate.Docs.GettingStarted.QuickStart.Commands
 {
-
     public class SpendPoints : Command<LoyaltyDB, Customer>
     {
         public SpendPoints()

--- a/Memstate.Docs.GettingStarted/QuickStart/Commands/TransferPoints.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Commands/TransferPoints.cs
@@ -1,0 +1,53 @@
+﻿using Newtonsoft.Json;
+
+namespace Memstate.Docs.GettingStarted.QuickStart.Commands
+{
+    public class TransferPointsResult
+    {
+        public TransferPointsResult(Customer sender, Customer recipient)
+        {
+            Sender = sender;
+            Recipient = recipient;
+        }
+
+        public Customer Sender { get; }
+        public Customer Recipient { get; }
+    }
+
+    public class TransferPoints : Command<LoyaltyDB, TransferPointsResult>
+    {
+        public TransferPoints()
+        {
+        }
+
+        public TransferPoints(int senderId, int recieverId, int points)
+        {
+            SenderId = senderId;
+            RecieverId = recieverId;
+            Points = points;
+        }
+
+        [JsonProperty("RecieverId")]
+        public int RecieverId { get; set;  }
+
+        [JsonProperty("SenderId")]
+        public int SenderId { get; set;  }
+
+        [JsonProperty("Points")]
+        public int Points { get; set; }
+
+        // it is safe to return actual references to Customer objects, because they are immutable.
+
+        public override TransferPointsResult Execute(LoyaltyDB model)
+        {
+            var sender = model.Customers[SenderId];
+            var receiver = model.Customers[RecieverId];
+            var newSender = new Customer(sender.ID, sender.LoyaltyPointBalance - Points);
+            var newReceiver = new Customer(receiver.ID, receiver.LoyaltyPointBalance + Points);
+            model.Customers[SenderId] = newSender;
+            model.Customers[RecieverId] = newReceiver;
+            return new TransferPointsResult(newSender, newReceiver);
+        }
+    }
+
+}

--- a/Memstate.Docs.GettingStarted/QuickStart/Customer.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/Customer.cs
@@ -1,8 +1,5 @@
-﻿using System;
-
-namespace Memstate.Docs.GettingStarted.QuickStart
+﻿namespace Memstate.Docs.GettingStarted.QuickStart
 {
-    [Serializable]
     public class Customer
     {
         public Customer(int id, int loyaltyPointBalance)

--- a/Memstate.Docs.GettingStarted/QuickStart/LoyaltyDB.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/LoyaltyDB.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Memstate.Docs.GettingStarted.QuickStart
 {
-    [Serializable]
     public class LoyaltyDB
     {
         public IDictionary<int, Customer> Customers { get; } = new Dictionary<int, Customer>();

--- a/Memstate.Docs.GettingStarted/QuickStart/QuickStartTests.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/QuickStartTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Memstate.Docs.GettingStarted.QuickStart.Commands;
 using Memstate.Docs.GettingStarted.QuickStart.Queries;
@@ -10,27 +9,27 @@ namespace Memstate.Docs.GettingStarted.QuickStart
 {
     public class QuickStartTests
     {
-        private string Filename1 = "smoke_test_with_defaults1";
-        private string JournalFile1 = "smoke_test_with_defaults1.journal";
+        private string WireFileName = "smoke_test_with_defaults_wire";
+        private string WireJournalFile = "smoke_test_with_defaults_wire.journal";
 
-        private string Filename2 = "smoke_test_with_defaults2";
-        private string JournalFile2 = "smoke_test_with_defaults2.journal";
+        private string JsonFileName = "smoke_test_with_defaults_json";
+        private string JsonJournalFile = "smoke_test_with_defaults_json.journal";
 
         [SetUp]
         [TearDown]
         public void SetupTeardown()
         {
-            if (File.Exists(JournalFile1)) File.Delete(JournalFile1);
-            if (File.Exists(JournalFile2)) File.Delete(JournalFile2);
+            if (File.Exists(WireJournalFile)) File.Delete(WireJournalFile);
+            if (File.Exists(JsonJournalFile)) File.Delete(JsonJournalFile);
         }
 
         [Test]
          public async Task Simple_end_to_end_getting_started_using_default_wire_serializer_with_filesytem_storage()
         {
             Print("GIVEN I start a new Memstate engine for a LoyaltyDB using default settings");
-            Print($"   (using Wire format  & local filesystem storage)");
+            Print($"   (using Wire format & local filesystem storage)");
 
-            var settings = new MemstateSettings { StreamName = Filename1 };
+            var settings = new MemstateSettings { StreamName = WireFileName };
             var model1 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
 
             Print("AND I initialise the database with 20 customers, each with 10 loyalty points");
@@ -40,7 +39,7 @@ namespace Memstate.Docs.GettingStarted.QuickStart
             }
 
             Print("THEN a journal file should now exist on the filesystem");
-            Assert.True(File.Exists(JournalFile1));
+            Assert.True(File.Exists(WireJournalFile));
 
             Print("WHEN customer 5 and customer 12 each earn 190 and 290 loyalty points respectively");
 
@@ -55,7 +54,7 @@ namespace Memstate.Docs.GettingStarted.QuickStart
             await model1.DisposeAsync();
 
             Print("THEN a journal file should still exist with all the commands I've played up to now");
-            Assert.True(File.Exists(JournalFile1));
+            Assert.True(File.Exists(WireJournalFile));
 
             Print("WHEN I start up another engine");
             var model2 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
@@ -71,41 +70,45 @@ namespace Memstate.Docs.GettingStarted.QuickStart
             await model2.DisposeAsync();
         }
 
+        // rules for using Json serialisation
+        // ----------------------------------
+        // Commands must have public constructors
+        // properties must have { get; set; } or at minimum { get; private set; }
+        // properties must be marked with [JsonProperty("fieldname")]
+        // does not need to be marked with [Serialisable] attribute!
+        // NO special rules for the return types. Although it is good practice where possible to make these immutable.
+
         [Test]
         public async Task Simple_end_to_end_getting_started_configure_to_use_json_serializer_with_filesytem_storage()
         {
             Print("GIVEN I start a new Memstate engine for a LoyaltyDB using default settings");
-            Print($"   (using Json format  & local filesystem storage)");
+            Print($"   (using Json format & local filesystem storage)");
 
-            var settings = new MemstateSettings { StreamName = Filename2, Serializer = "Json" };
+            var settings = new MemstateSettings { StreamName = JsonFileName, Serializer = "Json" };
 
             settings.Serializers.Register("Json", _settings => new JsonNet.JsonSerializerAdapter(_settings));
 
             var model1 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
 
-            Print("AND I initialise the database with 20 customers, each with 10 loyalty points");
-            for (int i = 0; i < 20; i++)
-            {
-                await model1.ExecuteAsync(new InitCustomer(i + 1, 10));
-            }
+            Print("AND I initialise the database with 2 customers, each with 10, and 20 loyalty points");
+            await model1.ExecuteAsync(new InitCustomer(10, 10));
+            await model1.ExecuteAsync(new InitCustomer(20, 20));
 
             Print("THEN a journal file should now exist on the filesystem");
-            Assert.True(File.Exists(JournalFile2));
+            Assert.True(File.Exists(JsonJournalFile));
 
-            Print("WHEN customer 5 and customer 12 each earn 190 and 290 loyalty points respectively");
+            Print("WHEN customer 10 transfers 5 points to customer 20");
+            var result = await model1.ExecuteAsync(new TransferPoints(10, 20, 5));
 
-            var c1 = await model1.ExecuteAsync(new EarnPoints(5, 190));
-            var c2 = await model1.ExecuteAsync(new EarnPoints(12, 290));
-
-            Print("THEN the balance for them will have increased to 200 and 300 loyalty points for customer 5 and 12 respectively");
-            Assert.AreEqual(200, c1.LoyaltyPointBalance);
-            Assert.AreEqual(300, c2.LoyaltyPointBalance);
+            Print("THEN the new balance for them will be 5 and 25 respectively");
+            Assert.AreEqual(5, result.Sender.LoyaltyPointBalance);
+            Assert.AreEqual(25, result.Recipient.LoyaltyPointBalance);
 
             Print("WHEN I dispose of the memstate engine");
             await model1.DisposeAsync();
 
             Print("THEN a journal file should still exist with all the commands I've played up to now");
-            Assert.True(File.Exists(JournalFile2));
+            Assert.True(File.Exists(JsonJournalFile));
 
             Print("WHEN I start up another engine");
             var model2 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
@@ -114,9 +117,9 @@ namespace Memstate.Docs.GettingStarted.QuickStart
             var allCustomers = await model2.ExecuteAsync(new GetCustomers());
 
             Print("AND the database should be restored to the exact same state it was after the last command was executed");
-            Assert.AreEqual(20, allCustomers.Count);
-            Assert.AreEqual(200, allCustomers[5].LoyaltyPointBalance);
-            Assert.AreEqual(300, allCustomers[12].LoyaltyPointBalance);
+            Assert.AreEqual(2, allCustomers.Count);
+            Assert.AreEqual(5, allCustomers[10].LoyaltyPointBalance);
+            Assert.AreEqual(25, allCustomers[20].LoyaltyPointBalance);
 
             await model2.DisposeAsync();
         }

--- a/Memstate.Docs.GettingStarted/QuickStart/QuickStartTests.cs
+++ b/Memstate.Docs.GettingStarted/QuickStart/QuickStartTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Memstate.Docs.GettingStarted.QuickStart.Commands;
 using Memstate.Docs.GettingStarted.QuickStart.Queries;
@@ -9,27 +10,29 @@ namespace Memstate.Docs.GettingStarted.QuickStart
 {
     public class QuickStartTests
     {
-        private string Filename = "smoke_test_with_defaults";
-        private string JournalFile = "smoke_test_with_defaults.journal";
+        private string Filename1 = "smoke_test_with_defaults1";
+        private string JournalFile1 = "smoke_test_with_defaults1.journal";
+
+        private string Filename2 = "smoke_test_with_defaults2";
+        private string JournalFile2 = "smoke_test_with_defaults2.journal";
 
         [SetUp]
         [TearDown]
-        public void Setup()
+        public void SetupTeardown()
         {
-            if (File.Exists(JournalFile)) File.Delete(JournalFile);
+            if (File.Exists(JournalFile1)) File.Delete(JournalFile1);
+            if (File.Exists(JournalFile2)) File.Delete(JournalFile2);
         }
 
-        // Hi all, here's some important notes on writing tests for .net core and standard,
-        // in case you want to create your own tests.
-        // https://github.com/nunit/docs/wiki/.NET-Core-and-.NET-Standard
-
         [Test]
-        public async Task Simple_end_to_end_getting_started_using_default_settings_with_filesytem_storage()
+         public async Task Simple_end_to_end_getting_started_using_default_wire_serializer_with_filesytem_storage()
         {
             Print("GIVEN I start a new Memstate engine for a LoyaltyDB using default settings");
-            Print("   (using Wire format  & local filesystem storage)");
-            var settings = new MemstateSettings { StreamName = Filename };
+            Print($"   (using Wire format  & local filesystem storage)");
+
+            var settings = new MemstateSettings { StreamName = Filename1 };
             var model1 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
+
             Print("AND I initialise the database with 20 customers, each with 10 loyalty points");
             for (int i = 0; i < 20; i++)
             {
@@ -37,7 +40,7 @@ namespace Memstate.Docs.GettingStarted.QuickStart
             }
 
             Print("THEN a journal file should now exist on the filesystem");
-            Assert.True(File.Exists(JournalFile));
+            Assert.True(File.Exists(JournalFile1));
 
             Print("WHEN customer 5 and customer 12 each earn 190 and 290 loyalty points respectively");
 
@@ -52,7 +55,57 @@ namespace Memstate.Docs.GettingStarted.QuickStart
             await model1.DisposeAsync();
 
             Print("THEN a journal file should still exist with all the commands I've played up to now");
-            Assert.True(File.Exists(JournalFile));
+            Assert.True(File.Exists(JournalFile1));
+
+            Print("WHEN I start up another engine");
+            var model2 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
+
+            Print("THEN the entire journal at this point should immediately replay all the journaled commands saved to the filesystem");
+            var allCustomers = await model2.ExecuteAsync(new GetCustomers());
+
+            Print("AND the database should be restored to the exact same state it was after the last command was executed");
+            Assert.AreEqual(20, allCustomers.Count);
+            Assert.AreEqual(200, allCustomers[5].LoyaltyPointBalance);
+            Assert.AreEqual(300, allCustomers[12].LoyaltyPointBalance);
+
+            await model2.DisposeAsync();
+        }
+
+        [Test]
+        public async Task Simple_end_to_end_getting_started_configure_to_use_json_serializer_with_filesytem_storage()
+        {
+            Print("GIVEN I start a new Memstate engine for a LoyaltyDB using default settings");
+            Print($"   (using Json format  & local filesystem storage)");
+
+            var settings = new MemstateSettings { StreamName = Filename2, Serializer = "Json" };
+
+            settings.Serializers.Register("Json", _settings => new JsonNet.JsonSerializerAdapter(_settings));
+
+            var model1 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);
+
+            Print("AND I initialise the database with 20 customers, each with 10 loyalty points");
+            for (int i = 0; i < 20; i++)
+            {
+                await model1.ExecuteAsync(new InitCustomer(i + 1, 10));
+            }
+
+            Print("THEN a journal file should now exist on the filesystem");
+            Assert.True(File.Exists(JournalFile2));
+
+            Print("WHEN customer 5 and customer 12 each earn 190 and 290 loyalty points respectively");
+
+            var c1 = await model1.ExecuteAsync(new EarnPoints(5, 190));
+            var c2 = await model1.ExecuteAsync(new EarnPoints(12, 290));
+
+            Print("THEN the balance for them will have increased to 200 and 300 loyalty points for customer 5 and 12 respectively");
+            Assert.AreEqual(200, c1.LoyaltyPointBalance);
+            Assert.AreEqual(300, c2.LoyaltyPointBalance);
+
+            Print("WHEN I dispose of the memstate engine");
+            await model1.DisposeAsync();
+
+            Print("THEN a journal file should still exist with all the commands I've played up to now");
+            Assert.True(File.Exists(JournalFile2));
 
             Print("WHEN I start up another engine");
             var model2 = await new EngineBuilder(settings).BuildAsync<LoyaltyDB>().ConfigureAwait(false);

--- a/Memstate.JsonNet/JsonSerializerAdapter.cs
+++ b/Memstate.JsonNet/JsonSerializerAdapter.cs
@@ -59,7 +59,7 @@ namespace Memstate.JsonNet
             var writer = new JsonTextWriter(streamWriter);
             
             _serializer.Serialize(writer, @object);
-            
+            streamWriter.WriteLine();
             writer.Flush();
             streamWriter.Flush();
         }


### PR DESCRIPTION
new getting started unit test showing how to configure memstate to use Json format journal files.

`Simple_end_to_end_getting_started_configure_to_use_json_serializer_with_filesytem_storage()`

Plus, update to `JsonSerializerAdapter.cs` to support 1 line per command. 
