### PR TITLE
Don't acquire config lock when it's not needed

### DIFF
--- a/src/Memstate.Core/Configuration/Config.cs
+++ b/src/Memstate.Core/Configuration/Config.cs
@@ -49,10 +49,14 @@ namespace Memstate.Configuration
         {
             get
             {
-                lock (_lock)
+                if (_current == null)
                 {
-                    if (_current == null) _current = BuildDefault();
+                    lock (_lock)
+                    {
+                        if (_current == null) _current = BuildDefault();
+                    }
                 }
+                
                 return _current;
             }
             internal set


### PR DESCRIPTION
Currently it will lock whenever you are requesting the current configuration despite only doing an action when it not set. 

Throughout the Memstate project this is done most commonly in constructors so the adverse effects from this would be relatively limited but it will help protect against users that create multiple `Client` objects for the same model (e.g. by not making it a singleton and injecting it in an ASP.NET controller which has a request lifetime) which would in turn trigger the entire cascade of locks on the config.

The config does expose a `Reset()` method so I see one scenario where a race condition occurs: if the config is set and thread A does a `Reset()` while thread B does a `get`, thread A could acquire the lock while thread B will return from the method early. 

It's up to you to decide whether this is important. The way I see it:

* This is very unlikely (who resets a persistence config at runtime?)
* This is very similar to a natural occurrence (the "race condition" might've happened anyway if, for example, the OS scheduled Thread A to run a few moments later)
* In the worst case, your persistence uses the old config for a tiny bit longer than expected
* The trade-off is a potential large decrease of config locking