### PR TITLE
Docs/general tweaks :  add link to getting started doc at top and bottom of intro readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Memstate
 
-[Documentation](docs)
-[Full quick start getting started sample code here...](/src/Memstate.Docs.GettingStarted/QuickStart)
+[Detailed Documentation](docs) | [quickstart](/src/Memstate.Docs.GettingStarted/QuickStart)
 
 [![Join the chat at https://gitter.im/memstate/lobby](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/memstate/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -129,4 +128,4 @@ Memstate relies on a backing storage provider for persistence and global message
 
 * **Kafka** - discontinued, end to end latency is too poor.
 
-[Full quick start getting started sample code here...](/src/Memstate.Docs.GettingStarted/QuickStart)
+[Detailed Documentation](docs) | [quickstart](/src/Memstate.Docs.GettingStarted/QuickStart)

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ As the journal grows over time, replaying billions of commands can take a signif
 
 ## Quickstart - getting started
 
-[Full quick start getting started sample code here...](/src/Memstate.Docs.GettingStarted/QuickStart)
-
+[Quickstart](/src/Memstate.Docs.GettingStarted/QuickStart) | [Detailed Documentation](docs) 
 
 ## Governance, Support and Contributions
 Memstate is an open source project sponsored and governed by Devrex Labs, an LLC based in Sweden.
@@ -128,4 +127,4 @@ Memstate relies on a backing storage provider for persistence and global message
 
 * **Kafka** - discontinued, end to end latency is too poor.
 
-[Detailed Documentation](docs) | [quickstart](/src/Memstate.Docs.GettingStarted/QuickStart)
+[Quickstart](/src/Memstate.Docs.GettingStarted/QuickStart) | [Detailed Documentation](docs) 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Memstate
 
 [Documentation](docs)
+[Full quick start getting started sample code here...](/src/Memstate.Docs.GettingStarted/QuickStart)
 
 [![Join the chat at https://gitter.im/memstate/lobby](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/memstate/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -127,3 +128,5 @@ Memstate relies on a backing storage provider for persistence and global message
 * **Kinesis** (AWS) - discontinued, end to end latency is too poor.
 
 * **Kafka** - discontinued, end to end latency is too poor.
+
+[Full quick start getting started sample code here...](/src/Memstate.Docs.GettingStarted/QuickStart)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Memstate
 
-[Detailed Documentation](docs) | [quickstart](/src/Memstate.Docs.GettingStarted/QuickStart)
+[Quickstart](/src/Memstate.Docs.GettingStarted/QuickStart) | [Detailed Documentation](docs) 
 
 [![Join the chat at https://gitter.im/memstate/lobby](https://badges.gitter.im/DevrexLabs/memstate.svg)](https://gitter.im/memstate/lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -61,7 +61,7 @@ As the journal grows over time, replaying billions of commands can take a signif
 
 ## Quickstart - getting started
 
-[Quickstart](/src/Memstate.Docs.GettingStarted/QuickStart) | [Detailed Documentation](docs) 
+[Quickstart](/src/Memstate.Docs.GettingStarted/QuickStart)
 
 ## Governance, Support and Contributions
 Memstate is an open source project sponsored and governed by Devrex Labs, an LLC based in Sweden.


### PR DESCRIPTION
Neaten up the home page documentation, add easy to access link to the getting started and full documentation at the top, middle and bottom of the introductory main screen readme.